### PR TITLE
reactive subordinates should use venv

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -2,3 +2,6 @@ includes:
   - 'layer:basic'
   - 'interface:elastic-beats'
   - 'interface:elasticsearch'  
+options:
+  basic:
+    use_venv: true


### PR DESCRIPTION
I ran into an issue today where my layer-apache-hadoop-namenode was using a newer version of charms.reactive than the filebeat charm in the store.

The filebeat charm stomped on my namenode's installation of charms.reactive. To prevent this, please update layer-beats-base to use a venv so the subordinate's python stuffs don't stomp the principal (this will propagate to filebeat, etc that build off of beats-base).

FYI, this is the error I got due to conflicting charms.reactive modules:

http://paste.ubuntu.com/15801060/
