### PR TITLE
Packetbeat services must be ints

### DIFF
--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -57,8 +57,8 @@ def parse_protocols():
     for protocol in protocols.split(' '):
         proto, port = protocol.strip().split(':')
         if proto in bag:
-            bag[proto].append(port)
+            bag[proto].append(int(port))
         else:
             bag.update({proto: []})
-            bag[proto].append(port)
+            bag[proto].append(int(port))
     return bag


### PR DESCRIPTION
The current rendering of service data was converting the ports to strings. This preserves their int intentions so the shipping agent doesn't fail a config test
