### PR TITLE
Adding a .gitignore to ignore the .tox directory for beats charms.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+*~
+.ropeproject
+.settings
+.tox
+.DS_Store


### PR DESCRIPTION
Technically the .gitignore file from layer-basic is sufficient for our needs, but is being overwritten by layer-apt's .gitignore which does not ignore the .tox directory.
