### PR TITLE
handle fields like we do logpath

### DIFF
--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -35,7 +35,9 @@ def render_without_context(source, target):
     if 'protocols' in context.keys():
         context.update({'protocols': parse_protocols()})
 
-    # Split the log paths
+    # Split space delimited config items
+    if 'fields' in context.keys() and not isinstance(context['fields'], list):  # noqa
+        context['fields'] = context['fields'].split(' ')
     if 'logpath' in context.keys() and not isinstance(context['logpath'], list):  # noqa
         context['logpath'] = context['logpath'].split(' ')
 

--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -36,9 +36,11 @@ def render_without_context(source, target):
         context.update({'protocols': parse_protocols()})
 
     # Split space delimited config items
-    if 'fields' in context.keys() and not isinstance(context['fields'], list):  # noqa
+    if ('fields' in context.keys() and context['fields'] and not
+            isinstance(context['fields'], list)):
         context['fields'] = context['fields'].split(' ')
-    if 'logpath' in context.keys() and not isinstance(context['logpath'], list):  # noqa
+    if ('logpath' in context.keys() and context['logpath'] and not
+            isinstance(context['logpath'], list)):
         context['logpath'] = context['logpath'].split(' ')
 
     render(source, target, context)


### PR DESCRIPTION
Originally reported in https://github.com/juju-solutions/layer-filebeat/issues/39, we do not properly split the `fields` config value.  Fix this by handling fields just like we do `logpath`.