### PR TITLE
fix connected waiting status

### DIFF
--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -10,7 +10,7 @@ def config_changed():
     set_state('beat.render')
 
 
-@when_not('logstash.connected', 'elasticsearch.connected', 'kafka.ready')
+@when_not('logstash.available', 'elasticsearch.available', 'kafka.ready')
 def waiting_messaging():
     status.waiting('Waiting for: elasticsearch, logstash or kafka.')
 


### PR DESCRIPTION
The requires side of the `elastic-beats` interface needs to wait for `<relation>.available`, not `<relation>.connected`:

https://github.com/juju-solutions/interface-elastic-beats/blob/master/requires.py