### PR TITLE
match upstream repo; add common log config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,24 @@
 options:
   install_sources:
     type: string
-    default: deb http://packages.elastic.co/beats/apt stable main
-    description: apt repository to fetch beats from
+    default: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+    description: "Elastic Beats apt repository"
   install_keys:
     type: string
-    default: 46095ACC8548582C1A2699A9D27D666CD88E42B4
-    description: repository key
+    default: D88E42B4
+    description: "Elastic Beats apt repository key"
+  log_level:
+    type: string
+    default: "info"
+    description: |
+      Beats log level. One of debug, info, warning, error, or critical:
+      https://www.elastic.co/guide/en/beats/filebeat/5.6/configuration-logging.html#level
+  logging_to_syslog:
+    type: boolean
+    default: true
+    description: |
+      Send beats logs to syslog:
+      https://www.elastic.co/guide/en/beats/filebeat/5.6/configuration-logging.html#_to_syslog
   logstash_hosts:
     type: string
     default: ""


### PR DESCRIPTION
Previous apt repo used the 2.x syntax; get with the times and use the current repo/key from upstream (note, this still defaults ES components to v5, but can be overridden in each beat as necessary).

Move common logging config to this layer (furtherance of #31). There aren't any handlers for these config options in this layer -- that is done in the relevant templates per beat.