### PR TITLE
set flag if k8s metadata prereqs are found

### DIFF
--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -45,7 +45,7 @@ def render_without_context(source, target):
         context.update({'has_containers': True})
     if path.isdir('/var/lib/docker/containers'):
         context.update({'has_docker': True})
-    if context['kube_logs'] and path.isfile('/root/.kube/config'):
+    if context.get('kube_logs', False) and path.isfile('/root/.kube/config'):
         context.update({'has_k8s': True})
 
     if 'protocols' in context.keys():

--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -45,6 +45,8 @@ def render_without_context(source, target):
         context.update({'has_containers': True})
     if path.isdir('/var/lib/docker/containers'):
         context.update({'has_docker': True})
+    if context['kube_logs'] and path.isfile('/root/.kube/config'):
+        context.update({'has_k8s': True})
 
     if 'protocols' in context.keys():
         context.update({'protocols': parse_protocols()})


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/filebeat-charm/+bug/1858668

We can only process k8s metdata if `kube_logs=True` **and** `/root/.kube/config` exists.  Make a new flag so the templates can render this scenario properly.