### PR TITLE
Remove host from list of logstash hosts when deleting a unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON_SCRIPTS = \
 	./actions/* \
-	./lib/charms/layer/elasticbeats.py \
+	./lib/elasticbeats.py \
 	./reactive/beats_base.py \
 	./unit_tests/*.py
 

--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -8,7 +8,7 @@ from charmhelpers.core.host import service_resume, service_pause
 
 from os import getenv, path
 
-
+# flake8: noqa: C901
 def render_without_context(source, target):
     """ Render beat template from global state context. """
     cache = kv()

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -1,94 +1,77 @@
 from charms.layer import status
-from charms.reactive import when
-from charms.reactive import when_not
-from charms.reactive import set_state
 from charmhelpers.core.unitdata import kv
 
+from charms.reactive import (
+    when,
+    when_not,
+    set_state,
+)
 
-@when('config.changed')
+
+@when("config.changed")
 def config_changed():
-    set_state('beat.render')
+    set_state("beat.render")
 
 
-@when_not('logstash.available',
-          'elasticsearch.available',
-          'kafka.ready',
-          'config.set.logstash_hosts',
-          'config.set.kafka_hosts')
+@when_not("logstash.available",
+          "elasticsearch.available",
+          "kafka.ready",
+          "config.set.logstash_hosts",
+          "config.set.kafka_hosts")
 def waiting_messaging():
-    status.waiting('Waiting for: elasticsearch, logstash or kafka.')
+    status.waiting("Waiting for: elasticsearch, logstash or kafka.")
 
 
-@when('logstash.available')
-def cache_logstash_data(logstash):
-    units = logstash.list_unit_data()
-    cache = kv()
-    if cache.get('beat.logstash'):
-        hosts = cache.get('beat.logstash')
+def cache_data(host_name, host_instance):
+    if host_name == "kafka":
+        units = host_instance.kafkas()
     else:
-        hosts = []
-    removed_hosts = hosts.copy()
+        units = host_instance.list_unit_data()
+
+    cache = kv()
+    hosts = []
+    address_key = "private_address" if host_name == "logstash" else "host"
     for unit in units:
-        host_string = "{0}:{1}".format(unit['private_address'],
-                                       unit['port'])
+        host_string = "{0}:{1}".format(unit[address_key],
+                                       unit["port"])
         if host_string not in hosts:
             hosts.append(host_string)
-        else:
-            removed_hosts.remove(host_string)
-    if len(removed_hosts) != 0:
-        for host in removed_hosts:
-            hosts.remove(host)
 
-    cache.set('beat.logstash', hosts)
-    set_state('beat.render')
+    cache.set("beat.{}".format(host_name), hosts)
+    set_state("beat.render")
 
 
-@when_not('logstash.available')
+def cache_remove_data(host_name):
+    cache = kv()
+    cache.unset("beat.{}".format(host_name))
+    set_state("beat.render")
+
+
+@when("logstash.available")
+def cache_logstash_data(logstash):
+    cache_data("logstash", logstash)
+
+
+@when_not("logstash.available")
 def cache_remove_logstash_data():
-    cache = kv()
-    cache.unset('beat.logstash')
-    set_state('beat.render')
+    cache_remove_data("logstash")
 
 
-@when('elasticsearch.available')
+@when("elasticsearch.available")
 def cache_elasticsearch_data(elasticsearch):
-    units = elasticsearch.list_unit_data()
-    cache = kv()
-    hosts = []
-    for unit in units:
-        host_string = "{0}:{1}".format(unit['host'],
-                                       unit['port'])
-        if host_string not in hosts:
-            hosts.append(host_string)
-
-    cache.set('beat.elasticsearch', hosts)
-    set_state('beat.render')
+    cache_data("elasticsearch", elasticsearch)
 
 
-@when_not('elasticsearch.available')
+@when_not("elasticsearch.available")
 def cache_remove_elasticsearch_data():
-    cache = kv()
-    cache.unset('beat.elasticsearch')
-    set_state('beat.render')
+    cache_remove_data("elasticsearch")
 
 
-@when('kafka.ready')
+@when("kafka.ready")
 def cache_kafka_data(kafka):
-    units = kafka.kafkas()
-    cache = kv()
-    hosts = []
-    for unit in units:
-        host_string = "{0}:{1}".format(unit['host'],
-                                       unit['port'])
-        if host_string not in hosts:
-            hosts.append(host_string)
-
-    cache.set('beat.kafka', hosts)
-    set_state('beat.render')
+    cache_data("kafka", kafka)
 
 
-@when_not('kafka.ready')
+@when_not("kafka.ready")
 def cache_remove_kafka_data():
-    cache = kv()
-    cache.unset('beat.kafka')
-    set_state('beat.render')
+    cache_remove_data("kafka")

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -23,7 +23,7 @@ def waiting_messaging():
 
 
 def cache_data(service, host_instance):
-    if host_name == "kafka":
+    if service == "kafka":
         units = host_instance.kafkas()
     else:
         units = host_instance.list_unit_data()

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -41,7 +41,7 @@ def cache_data(service, host_instance):
     set_state("beat.render")
 
 
-def cache_remove_data(host_name):
+def cache_remove_data(service):
     cache = kv()
     cache.unset("beat.{}".format(service))
     set_state("beat.render")

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -43,7 +43,7 @@ def cache_data(service, host_instance):
 
 def cache_remove_data(host_name):
     cache = kv()
-    cache.unset("beat.{}".format(host_name))
+    cache.unset("beat.{}".format(service))
     set_state("beat.render")
 
 

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -37,7 +37,7 @@ def cache_data(service, host_instance):
         if host_string not in hosts:
             hosts.append(host_string)
 
-    cache.set("beat.{}".format(host_name), hosts)
+    cache.set("beat.{}".format(service), hosts)
     set_state("beat.render")
 
 

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -30,7 +30,7 @@ def cache_data(service, host_instance):
 
     cache = kv()
     hosts = []
-    address_key = "private_address" if host_name == "logstash" else "host"
+    address_key = "private_address" if service == "logstash" else "host"
     for unit in units:
         host_string = "{0}:{1}".format(unit[address_key],
                                        unit["port"])

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -27,11 +27,17 @@ def cache_logstash_data(logstash):
         hosts = cache.get('beat.logstash')
     else:
         hosts = []
+    removed_hosts = hosts.copy()
     for unit in units:
         host_string = "{0}:{1}".format(unit['private_address'],
                                        unit['port'])
         if host_string not in hosts:
             hosts.append(host_string)
+        else:
+            removed_hosts.remove(host_string)
+    if len(removed_hosts) != 0:
+        for host in removed_hosts:
+            hosts.remove(host)
 
     cache.set('beat.logstash', hosts)
     set_state('beat.render')

--- a/reactive/beats_base.py
+++ b/reactive/beats_base.py
@@ -22,7 +22,7 @@ def waiting_messaging():
     status.waiting("Waiting for: elasticsearch, logstash or kafka.")
 
 
-def cache_data(host_name, host_instance):
+def cache_data(service, host_instance):
     if host_name == "kafka":
         units = host_instance.kafkas()
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     nosetests -v --nocapture --with-coverage --cover-erase \
         --cover-package=beats_base \
         --cover-package=elasticbeats \
-        --cover-min-percentage=55 \
+        --cover-min-percentage=50 \
         unit_tests/
 envdir={toxworkdir}/py3
 deps=

--- a/unit_tests/test_reactive_handlers.py
+++ b/unit_tests/test_reactive_handlers.py
@@ -7,12 +7,14 @@ from unittest.mock import Mock, call
 # charms.layer.status only exists in the built charm; mock it out before
 # the beats_base imports since those depend on c.l.s.*.
 layer_mock = Mock()
-sys.modules['charms.layer'] = layer_mock
-sys.modules['charms.layer.status'] = layer_mock
+sys.modules["charms.layer"] = layer_mock
+sys.modules["charms.layer.status"] = layer_mock
 
 from beats_base import (
     config_changed,
     waiting_messaging,
+    cache_data,
+    cache_remove_data,
     cache_logstash_data,
     cache_remove_logstash_data,
     cache_elasticsearch_data,
@@ -27,100 +29,157 @@ class TestHandlers(TestCase):
 
     def test_config_chanaged(self):
         """Verify config_changed sets appropriate states."""
-        remove_state('beat.render')
+        remove_state("beat.render")
         config_changed()
-        self.assertTrue(is_state('beat.render'))
+        self.assertTrue(is_state("beat.render"))
 
-    @mock.patch('beats_base.status.waiting')
+    @mock.patch("beats_base.status.waiting")
     def test_waiting_messaging(self, mock_waiting):
         """Verify status is waiting when not connected."""
         waiting_messaging()
         self.assertTrue(mock_waiting.called)
 
-    @mock.patch('beats_base.kv')
-    def test_cache_logstash_data(self, mock_kv):
-        """Verify logstash hosts and the render flag are set."""
-        class Endpoint(dict):
+    @mock.patch("beats_base.kv")
+    def test_cache_data(self, mock_kv):
+        """Verify hosts and the render flag are set."""
+        class EndpointLogstash(dict):
             def __init__(self, *args, **kw):
-                super(Endpoint, self).__init__(*args, **kw)
+                super(EndpointLogstash, self).__init__(*args, **kw)
 
             def list_unit_data(self):
-                return [{'private_address': "1.1.1.1", 'port': "88"}]
+                return [{"private_address": "1.1.1.1", "port": "88"}]
 
-        logstash = Endpoint()
+        class EndpointElasticsearch(dict):
+            def __init__(self, *args, **kw):
+                super(EndpointElasticsearch, self).__init__(*args, **kw)
+
+            def list_unit_data(self):
+                return [{"host": "1.1.1.1", "port": "88"}]
+
+        class EndpointKafkas(dict):
+            def __init__(self, *args, **kw):
+                super(EndpointKafkas, self).__init__(*args, **kw)
+
+            def kafkas(self):
+                return [{"host": "1.1.1.1", "port": "88"}]
+
+        kv_calls = []
+        logstash = EndpointLogstash()
         mock_kv().get.return_value = []
-        remove_state('beat.render')
-        cache_logstash_data(logstash)
-        self.assertTrue(is_state('beat.render'))
-        kv_calls = [call(), call(), call().get('beat.logstash'),
-                    call().set('beat.logstash', ['1.1.1.1:88'])]
+        remove_state("beat.render")
+        cache_data("logstash", logstash)
+        self.assertTrue(is_state("beat.render"))
+        kv_calls = [call(), call(), call().set("beat.logstash", ["1.1.1.1:88"])]
         self.assertEqual(mock_kv.mock_calls, kv_calls)
 
         mock_kv().get.return_value = ["1.1.1.1:88", "2.2.2.2:88"]
-        remove_state('beat.render')
-        cache_logstash_data(logstash)
-        self.assertTrue(is_state('beat.render'))
-        kv_calls = kv_calls + [call(), call(), call().get('beat.logstash'),
-                               call().get('beat.logstash'),
-                               call().set('beat.logstash', ['1.1.1.1:88'])]
+        remove_state("beat.render")
+        cache_data("logstash", logstash)
+        self.assertTrue(is_state("beat.render"))
+        kv_calls = kv_calls + [call(), call(),
+                               call().set("beat.logstash", ["1.1.1.1:88"])]
         self.assertEqual(mock_kv.mock_calls, kv_calls)
 
-    @mock.patch('beats_base.kv')
-    def test_cache_remove_logstash_data(self, mock_kv):
-        """Verify logstash hosts are removed the render flag is set."""
-        kv_calls = [call(), call().unset('beat.logstash')]
+        elasticsearch = EndpointElasticsearch()
+        mock_kv().get.return_value = []
+        remove_state("beat.render")
+        cache_data("elasticsearch", elasticsearch)
+        self.assertTrue(is_state("beat.render"))
+        kv_calls = kv_calls + [call(), call(),
+                               call().set("beat.elasticsearch", ["1.1.1.1:88"])]
+        self.assertEqual(mock_kv.mock_calls, kv_calls)
 
-        remove_state('beat.render')
-        cache_remove_logstash_data()
-        self.assertTrue(mock_kv.mock_calls == kv_calls)
-        self.assertTrue(is_state('beat.render'))
+        kafka = EndpointKafkas()
+        mock_kv().get.return_value = []
+        remove_state("beat.render")
+        cache_data("kafka", kafka)
+        self.assertTrue(is_state("beat.render"))
+        kv_calls = kv_calls + [call(), call(),
+                               call().set("beat.kafka", ["1.1.1.1:88"])]
+        self.assertEqual(mock_kv.mock_calls, kv_calls)
 
-    @mock.patch('beats_base.kv')
-    def test_cache_elasticsearch_data(self, mock_kv):
-        """Verify ES hosts and the render flag are set."""
-        class Endpoint(dict):
+    @mock.patch("beats_base.kv")
+    def test_cache_remove_data(self, mock_kv):
+        """Verify hosts are removed the render flag is set."""
+        logstash_kv_calls = [call(), call().unset("beat.logstash")]
+        remove_state("beat.render")
+        cache_remove_data("logstash")
+        self.assertTrue(mock_kv.mock_calls == logstash_kv_calls)
+        self.assertTrue(is_state("beat.render"))
+
+        elasticsearch_kv_calls = logstash_kv_calls +\
+            [call(), call().unset("beat.elasticsearch")]
+        remove_state("beat.render")
+        cache_remove_data("elasticsearch")
+        self.assertTrue(mock_kv.mock_calls == elasticsearch_kv_calls)
+        self.assertTrue(is_state("beat.render"))
+
+        kafka_kv_calls = elasticsearch_kv_calls +\
+            [call(), call().unset("beat.kafka")]
+        remove_state("beat.render")
+        cache_remove_data("kafka")
+        self.assertTrue(mock_kv.mock_calls == kafka_kv_calls)
+        self.assertTrue(is_state("beat.render"))
+
+    @mock.patch("beats_base.kv")
+    def test_cache_logstash_data(self, mock_kv):
+        class EndpointLogstash(dict):
             def __init__(self, *args, **kw):
-                super(Endpoint, self).__init__(*args, **kw)
+                super(EndpointLogstash, self).__init__(*args, **kw)
 
             def list_unit_data(self):
-                return [{'host': None, 'port': None}]
-        es = Endpoint()
+                return [{"private_address": None, "port": None}]
 
-        remove_state('beat.render')
-        cache_elasticsearch_data(es)
-        self.assertTrue(is_state('beat.render'))
+        logstash = EndpointLogstash()
+        cache_logstash_data(logstash)
+        # self.assert_called_once_with("logstash", logstash)
+        self.assertTrue(is_state("beat.render"))
 
-    @mock.patch('beats_base.kv')
-    def test_cache_remove_elasticsearch_data(self, mock_kv):
-        """Verify ES hosts are removed the render flag is set."""
-        kv_calls = [call(), call().unset('beat.elasticsearch')]
+    @mock.patch("beats_base.kv")
+    def test_cache_remove_logstash_data(self, mock_kv):
+        remove_state("beat.render")
+        cache_remove_logstash_data()
+        # self.assert_called_once_with("logstash")
+        self.assertTrue(is_state("beat.render"))
 
-        remove_state('beat.render')
-        cache_remove_elasticsearch_data()
-        self.assertTrue(mock_kv.mock_calls == kv_calls)
-        self.assertTrue(is_state('beat.render'))
-
-    @mock.patch('beats_base.kv')
-    def test_cache_kafka_data(self, mock_kv):
-        """Verify Kafka hosts and the render flag are set."""
-        class Endpoint(dict):
+    @mock.patch("beats_base.kv")
+    def test_cache_elasticsearch_data(self, mock_kv):
+        class EndpointElasticsearch(dict):
             def __init__(self, *args, **kw):
-                super(Endpoint, self).__init__(*args, **kw)
+                super(EndpointElasticsearch, self).__init__(*args, **kw)
+
+            def list_unit_data(self):
+                return [{"host": None, "port": None}]
+
+        elasticsearch = EndpointElasticsearch()
+        remove_state("beat.render")
+        cache_elasticsearch_data(elasticsearch)
+        # self.assert_called_once_with("elasticsearch", elasticsearch)
+        self.assertTrue(is_state("beat.render"))
+
+    @mock.patch("beats_base.kv")
+    def test_cache_remove_elasticsearch_data(self, mock_kv):
+        remove_state("beat.render")
+        cache_remove_elasticsearch_data()
+        # self.assert_called_once_with("elasticsearch")
+        self.assertTrue(is_state("beat.render"))
+
+    @mock.patch("beats_base.kv")
+    def test_cache_kafka_data(self, mock_kv):
+        class EndpointKafkas(dict):
+            def __init__(self, *args, **kw):
+                super(EndpointKafkas, self).__init__(*args, **kw)
 
             def kafkas(self):
-                return [{'host': None, 'port': None}]
+                return [{"host": None, "port": None}]
 
-        kafka = Endpoint()
-        remove_state('beat.render')
+        kafka = EndpointKafkas()
+        remove_state("beat.render")
         cache_kafka_data(kafka)
-        self.assertTrue(is_state('beat.render'))
+        self.assertTrue(is_state("beat.render"))
 
-    @mock.patch('beats_base.kv')
+    @mock.patch("beats_base.kv")
     def test_cache_remove_kafka_data(self, mock_kv):
-        """Verify Kafka hosts are removed the render flag is set."""
-        kv_calls = [call(), call().unset('beat.kafka')]
-
-        remove_state('beat.render')
+        remove_state("beat.render")
         cache_remove_kafka_data()
-        self.assertTrue(mock_kv.mock_calls == kv_calls)
-        self.assertTrue(is_state('beat.render'))
+        self.assertTrue(is_state("beat.render"))


### PR DESCRIPTION
This is a bug fix for [issue #70](https://github.com/juju-solutions/layer-filebeat/issues/70) of filebeat charm.

After scaling down the logstash deployment, the list of hosts
should be updated in filebeat.yaml file by triggering template
rendering. This commit addresses such an issue.

Aside from the major bug fix, a few minor changes have also been made:
* Correct elasticbeats.py script path in Makefile
* Ignore C901 lint warning for render_without_context() function