### PR TITLE
drop dependency on charms.templating.jinja2

### DIFF
--- a/lib/elasticbeats.py
+++ b/lib/elasticbeats.py
@@ -5,11 +5,11 @@
 import subprocess
 from os import getenv, path
 
+from charmhelpers.contrib.templating.jinja import render
 from charmhelpers.core.hookenv import config, juju_version, log, principal_unit
-from charmhelpers.core.host import service_pause, service_resume
+from charmhelpers.core.host import mkdir, service_pause, service_resume, write_file
 from charmhelpers.core.unitdata import kv
 from charms.apt import get_package_version
-from charms.templating.jinja2 import render
 
 
 # flake8: noqa: C901
@@ -61,7 +61,11 @@ def render_without_context(source, target):
         if key in context.keys() and context[key] and not isinstance(context[key], list):
             context[key] = context[key].split(" ")
 
-    render(source, target, context)
+    rendered_template = render(source, context)
+    target_dir = path.dirname(target)
+    if not path.exists(target_dir):
+        mkdir(target_dir, perms=0o755)
+    write_file(target, rendered_template.encode("UTF-8"))
     return connected
 
 

--- a/tests/unit/test_elasticbeats.py
+++ b/tests/unit/test_elasticbeats.py
@@ -10,7 +10,7 @@ layer_mock = Mock()
 sys.modules["charms.apt"] = layer_mock
 sys.modules["charms.layer.status"] = layer_mock
 
-from elasticbeats import get_package_candidate  # noqa: E402
+from elasticbeats import enable_beat_on_boot, get_package_candidate  # noqa: E402
 
 
 class TestElasticBeats(TestCase):
@@ -54,3 +54,12 @@ class TestElasticBeats(TestCase):
         mock_sub.return_value = grep_proc
         mock_pkg_ver.return_value = "0"
         self.assertEqual("1.2.3", get_package_candidate("foo"))
+
+    @mock.patch("elasticbeats.remove_beat_on_boot")
+    @mock.patch("elasticbeats.service_resume")
+    def test_enable_beats_on_boot(self, resume_mock, remove_beat_on_boot_mock):
+        service_name = "filebeat.service"
+        enable_beat_on_boot(service_name)
+
+        resume_mock.assert_called_once_with(service_name)
+        remove_beat_on_boot_mock.assert_called_once_with(service_name)

--- a/tests/unit/test_elasticbeats.py
+++ b/tests/unit/test_elasticbeats.py
@@ -8,8 +8,6 @@ from unittest.mock import Mock
 # the elasticbeats imports since those depend on these layers.
 layer_mock = Mock()
 sys.modules["charms.apt"] = layer_mock
-sys.modules["charms.templating"] = layer_mock
-sys.modules["charms.templating.jinja2"] = layer_mock
 sys.modules["charms.layer.status"] = layer_mock
 
 from elasticbeats import get_package_candidate  # noqa: E402

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8<5.0  # https://github.com/tholo/pytest-flake8/issues/87
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,0 @@
-charms.templating.jinja2>1.0.0,<=2.0.0


### PR DESCRIPTION
This layer depends on [charm.templating.jinja2](https://github.com/juju-solutions/charms.templating.jinja2) layer which in turn brings in dependency on ancient python package [Tempita](https://pypi.org/project/Tempita/). `Tempita` does not work with python3.10 and this block charms that use this layer to be supported on Ubuntu 22.04.

Error when installing charm with `Tempita` on 22.04:
```
unit-filebeat-1: 16:37:32 INFO juju.worker.uniter found queued "upgrade-charm" hook
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm   error: subprocess-exited-with-error
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm   
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm   × python setup.py egg_info did not run successfully.
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm   │ exit code: 1
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm   ╰─> [1 lines of output]
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm       error in Tempita setup command: use_2to3 is invalid.
unit-filebeat-1: 16:37:46 WARNING unit.filebeat/1.upgrade-charm       [end of output]
```
This change substitutes [render() function from `charms.tempting.jinja2`](https://github.com/juju-solutions/charms.templating.jinja2/blob/b958f36c20eb46ce1b589e7e7c7f7deef658289e/charms/templating/jinja2.py#L27) for [render() function from `charmhelpers`](https://github.com/juju/charm-helpers/blob/96d51eed0c1e366877680443fac6c83afca29c36/charmhelpers/contrib/templating/jinja.py#L30). I believed that this change fully replaces every functionality from previous `render()` function.

I tested this change with `filebeat` charm and config file templating works fine.